### PR TITLE
docs: update README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = '2'
 members = ["api", "cli", "gui", "server", "service"]
 
 [profile.release]

--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -124,16 +124,19 @@ ChatWizard 支持内置升级，每当你重新启动应用时都会自动查询
 
 ## 开发
 
-- 启动
+### 全局依赖
+
+本项目依赖 `tauri-cli`，请确保系统中已经安装了 `tauri-cli`，如果没有安装，请使用 `cargo install tauri-cli` 进行安装。
+
+### 启动
 
     ```bash
-    # root
-    pnpm install
     pnpm run install
+    pnpm run build:web
     pnpm run dev
     ```
 
-- 打包
+### 打包
 
     ```bash
     pnpm run build

--- a/README.md
+++ b/README.md
@@ -183,16 +183,22 @@ Options:
 
 ## Development
 
-- dev
+### Prerequirements
+
+This project depends on `tauri-cli`. Please ensure that `tauri-cli` is already installed on your system.
+If it is not installed, please use `cargo install tauri-cli` to install it.
+
+
+### Dev
 
     ```bash
-    # root
-    pnpm install
     pnpm run install
+    pnpm run build:web
     pnpm run dev
     ```
 
-- build
+
+### Build
 
     ```bash
     pnpm run build


### PR DESCRIPTION
The section `Development` in README is incorrect for beginner.

- Add `workspace.resolver` to resolve the following warning
![image_1701143685120_0](https://github.com/lisiur/ChatWizard/assets/2386165/67cabe22-6159-405b-b22e-4970eb02b503)

- As the rust code requires `web/dist/`, we should build `web` first, otherwise it will throw error
![image_1701144291061_0](https://github.com/lisiur/ChatWizard/assets/2386165/83a953df-f679-41ba-bf56-9f4b13dd1417)
