### PR TITLE
Docker support for server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:alpine as builder
+ENV PNPM_HOME="/pnpm"
+RUN apk add --no-cache musl-dev build-base libc-dev libressl-dev nodejs npm
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+ENV PATH="$PATH:$PNPM_HOME"
+RUN npm install -g corepack
+RUN corepack enable
+RUN cargo install tauri-cli
+COPY . /build
+RUN cd /build && pnpm install && pnpm run build:web
+RUN cd /build/server && cargo build --release
+
+FROM alpine:latest as runner
+COPY --from=builder /build/target/release/chat-wizard-server /app/chat-wizard-server
+CMD ["/app/chat-wizard-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  chat-wizard-server:
+    container_name: chat-wizard-server
+    build: .
+    volumes:
+      - data:/root/.local/share/chat-wizard
+    ports:
+      - "23333:23333"
+volumes:
+  data:


### PR DESCRIPTION
Hey @lisiur,

Thank you for this project.

I have created a Dockerfile and docker-compose.yml for the server-version so that this can be deployed easily on a server.

Running `docker compose build` or `docker compose up --build` will build the server from source in a container where all dependencies are installed (will take a while) and then discard the build container and run it in a lightweight alpine container (total sized 30.7MB).

You may want to build it and upload it to dockerhub to be able to offer an image which can be executed with `docker run -p 23333:23333 -v /path/to/persistence:/root/.local/share/chat-wizard --restart unless-stopped <image name>`.

The configuration also makes sure data is persistent.

Keep up the good work!

Best,
THF